### PR TITLE
feat: retrieve current id of a request

### DIFF
--- a/client/src/websocket.rs
+++ b/client/src/websocket.rs
@@ -193,6 +193,11 @@ impl WebsocketClient {
 
         Ok(())
     }
+
+    /// Retrieve the current 'id' of a request made to websocket server
+    pub fn current_id(&self) -> u64 {
+        self.next_id - 1
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## What this PR does?
- As a public function to retrieve the current ID of a request sent by the websocket client
- This ID can be used in `::connect_stream(subscription_id)` to get a stream of notifications for the subscription ID